### PR TITLE
feature: add load testing to github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,6 @@
 branch = True
 source = hurricane/
 concurrency=multiprocessing
+omit =
+    hurricane/testing/start_k8s_server.py
+    hurricane/testing/start_webhook_receiver.py

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -24,6 +24,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install locust
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Run hurricane test server & locust load testing
+    - name: Lint with flake8
       run: |
-        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 25 -r 5 --host http://localhost:8000 --run-time 2m
+        python manage.py serve & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -26,4 +26,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run hurricane test server & locust load testing
       run: |
-        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 100 -r 10 --host http://localhost:8000 --run-time 2m
+        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 25 -r 5 --host http://localhost:8000 --run-time 2m

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -26,4 +26,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run hurricane test server & locust load testing
       run: |
-        python manage.py serve & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m
+        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -24,6 +24,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install locust
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Run hurricane test server & locust load testing
       run: |
         python manage.py serve & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -1,0 +1,29 @@
+name: Load Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  load_test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.8, 3.9 ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install locust
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        python manage.py serve & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m

--- a/.github/workflows/python-loadtest.yml
+++ b/.github/workflows/python-loadtest.yml
@@ -26,4 +26,4 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Run hurricane test server & locust load testing
       run: |
-        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 1000 -r 100 --host http://localhost:8000 --run-time 10m
+        nohup python manage.py serve > /dev/null 2>&1 & locust --headless -u 100 -r 10 --host http://localhost:8000 --run-time 2m

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.sources=hurricane
+sonar.exclusions=hurricane/testing/start_k8s_server.py

--- a/hurricane/kubernetes.py
+++ b/hurricane/kubernetes.py
@@ -1,17 +1,16 @@
 import asyncio
+import logging
 
 import tornado.web
-
-from .server import metrics_log
-
-logger = metrics_log
 
 
 class K8sServerMetricsHandler(tornado.web.RequestHandler):
     """This handler reports current usage statistics to Kubernetes"""
 
+    logger = logging.getLogger()
+
     def get(self):
         # write custom metrics to MetricsAPI in the future
         request_queue_length = len(asyncio.all_tasks())
-        logger.info(f"Request count: {request_queue_length}")
-        self.write(request_queue_length)
+        self.logger.info(f"Request count: {request_queue_length}")
+        self.write(f"{request_queue_length}".encode())

--- a/hurricane/management/commands/consume.py
+++ b/hurricane/management/commands/consume.py
@@ -163,10 +163,10 @@ class Command(BaseCommand):
         connection["amqp_vhost"] = "/"
         if "amqp_vhost" in options and options["amqp_vhost"]:
             connection["amqp_vhost"] = options["amqp_vhost"]
-        elif hasattr(settings, "AMPQ_VHOST"):
+        elif hasattr(settings, "AMQP_VHOST"):
             connection["amqp_vhost"] = settings.AMPQ_VHOST
-        elif os.getenv("AMPQ_VHOST"):
-            connection["amqp_vhost"] = os.getenv("AMPQ_VHOST")
+        elif os.getenv("AMQP_VHOST"):
+            connection["amqp_vhost"] = os.getenv("AMQP_VHOST")
 
         # load the handler class
         _amqp_consumer = import_string(options["handler"])

--- a/hurricane/testing/actors.py
+++ b/hurricane/testing/actors.py
@@ -6,6 +6,8 @@ import pika
 import tornado.ioloop
 import tornado.web
 
+from hurricane.kubernetes import K8sServerMetricsHandler
+
 logging.basicConfig(level=logging.INFO)
 
 
@@ -62,5 +64,14 @@ class WebhookReceiverServer:
         return tornado.web.Application(
             [
                 ("/webhook", WebhookTestHandler),
+            ]
+        )
+
+
+class K8sServer:
+    def make_http_receiver_app(self):
+        return tornado.web.Application(
+            [
+                ("/k8s", K8sServerMetricsHandler),
             ]
         )

--- a/hurricane/testing/start_k8s_server.py
+++ b/hurricane/testing/start_k8s_server.py
@@ -1,0 +1,16 @@
+import logging
+
+import tornado.ioloop
+
+from hurricane.testing.actors import K8sServer
+
+
+def start_server():
+    logging.info("Started K8s server")
+    app = K8sServer().make_http_receiver_app()
+    app.listen(8072)
+    tornado.ioloop.IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    start_server()

--- a/hurricane/testing/start_webhook_receiver.py
+++ b/hurricane/testing/start_webhook_receiver.py
@@ -4,8 +4,13 @@ import tornado.ioloop
 
 from hurricane.testing.actors import WebhookReceiverServer
 
-if __name__ == "__main__":
+
+def start_receiver():
     logging.info("Started webhook receiver server")
     app = WebhookReceiverServer().make_http_receiver_app()
     app.listen(8074)
     tornado.ioloop.IOLoop.current().start()
+
+
+if __name__ == "__main__":
+    start_receiver()

--- a/locustfile.py
+++ b/locustfile.py
@@ -34,7 +34,7 @@ def _(environment, **kw):
     elif environment.stats.total.avg_response_time > 300:
         logging.error("Test failed due to average response time ratio > 300 ms")
         environment.process_exit_code = 1
-    elif environment.stats.total.get_response_time_percentile(0.95) > 900:
+    elif environment.stats.total.get_response_time_percentile(0.95) > 950:
         logging.error("Test failed due to 95th percentile response time > 900 ms")
         environment.process_exit_code = 1
     else:

--- a/locustfile.py
+++ b/locustfile.py
@@ -23,7 +23,7 @@ def _(environment, **kw):
         logging.error("Test failed due to average response time ratio > 3 ms")
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 6:
-        logging.error("Test failed due to 95th percentile response time > 2 ms")
+        logging.error("Test failed due to 95th percentile response time > 6 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -4,12 +4,24 @@ from locust import HttpUser, between, events, task
 from locust.contrib.fasthttp import FastHttpUser
 
 
-class WebsiteUser(FastHttpUser):
+class HurricaneWebsiteUser(FastHttpUser):
     wait_time = between(5, 15)
+    url = "/"
+    weight = 1
 
     @task
-    def admin(self):
-        self.client.get("/")
+    def request(self):
+        self.client.get(self.url)
+
+
+class MediumHurricaneWebsiteUser(HurricaneWebsiteUser):
+    url = "/medium"
+    weight = 3
+
+
+class HeavyHurricaneWebsiteUser(HurricaneWebsiteUser):
+    url = "/heavy"
+    weight = 1
 
 
 @events.quitting.add_listener
@@ -19,11 +31,11 @@ def _(environment, **kw):
     if environment.stats.total.fail_ratio > 0.01:
         logging.error("Test failed due to failure ratio > 1%")
         environment.process_exit_code = 1
-    elif environment.stats.total.avg_response_time > 4:
-        logging.error("Test failed due to average response time ratio > 4 ms")
+    elif environment.stats.total.avg_response_time > 300:
+        logging.error("Test failed due to average response time ratio > 300 ms")
         environment.process_exit_code = 1
-    elif environment.stats.total.get_response_time_percentile(0.95) > 6:
-        logging.error("Test failed due to 95th percentile response time > 6 ms")
+    elif environment.stats.total.get_response_time_percentile(0.95) > 800:
+        logging.error("Test failed due to 95th percentile response time > 800 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -50,8 +50,8 @@ def _(environment, **kw):
     if environment.stats.total.fail_ratio > 0.01:
         logging.error("Test failed due to failure ratio > 1%")
         environment.process_exit_code = 1
-    elif environment.stats.total.avg_response_time > 6:
-        logging.error("Test failed due to average response time ratio > 3 ms")
+    elif environment.stats.total.avg_response_time > 4:
+        logging.error("Test failed due to average response time ratio > 4 ms")
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 6:
         logging.error("Test failed due to 95th percentile response time > 6 ms")

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,9 +1,29 @@
-from locust import HttpUser, between, task
+import logging
+
+from locust import HttpUser, between, events, task
+from locust.contrib.fasthttp import FastHttpUser
 
 
-class WebsiteUser(HttpUser):
+class WebsiteUser(FastHttpUser):
     wait_time = between(5, 15)
 
     @task
     def admin(self):
         self.client.get("/")
+
+
+@events.quitting.add_listener
+def _(environment, **kw):
+    logging.info(f"Average response time: {environment.stats.total.avg_response_time}")
+    logging.info(f"95th percentile response time: {environment.stats.total.get_response_time_percentile(0.95)}")
+    if environment.stats.total.fail_ratio > 0.01:
+        logging.error("Test failed due to failure ratio > 1%")
+        environment.process_exit_code = 1
+    elif environment.stats.total.avg_response_time > 6:
+        logging.error("Test failed due to average response time ratio > 3 ms")
+        environment.process_exit_code = 1
+    elif environment.stats.total.get_response_time_percentile(0.95) > 6:
+        logging.error("Test failed due to 95th percentile response time > 2 ms")
+        environment.process_exit_code = 1
+    else:
+        environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -54,7 +54,7 @@ def _(environment, **kw):
         logging.error("Test failed due to average response time ratio > 3 ms")
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 6:
-        logging.error("Test failed due to 95th percentile response time > 2 ms")
+        logging.error("Test failed due to 95th percentile response time > 6 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -28,8 +28,8 @@ class HeavyHurricaneWebsiteUser(HurricaneWebsiteUser):
 def _(environment, **kw):
     logging.info(f"Average response time: {environment.stats.total.avg_response_time}")
     logging.info(f"95th percentile response time: {environment.stats.total.get_response_time_percentile(0.95)}")
-    if environment.stats.total.fail_ratio > 0.01:
-        logging.error("Test failed due to failure ratio > 1%")
+    if environment.stats.total.fail_ratio > 0.025:
+        logging.error("Test failed due to failure ratio > 2.5%")
         environment.process_exit_code = 1
     elif environment.stats.total.avg_response_time > 300:
         logging.error("Test failed due to average response time ratio > 300 ms")

--- a/locustfile.py
+++ b/locustfile.py
@@ -4,6 +4,8 @@ from locust import HttpUser, between, events, task
 from locust.contrib.fasthttp import FastHttpUser
 
 
+class WebsiteUser(FastHttpUser):
+
 class HurricaneWebsiteUser(FastHttpUser):
     wait_time = between(5, 15)
     url = "/"
@@ -36,6 +38,23 @@ def _(environment, **kw):
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 800:
         logging.error("Test failed due to 95th percentile response time > 800 ms")
+        environment.process_exit_code = 1
+    else:
+        environment.process_exit_code = 0
+
+
+@events.quitting.add_listener
+def _(environment, **kw):
+    logging.info(f"Average response time: {environment.stats.total.avg_response_time}")
+    logging.info(f"95th percentile response time: {environment.stats.total.get_response_time_percentile(0.95)}")
+    if environment.stats.total.fail_ratio > 0.01:
+        logging.error("Test failed due to failure ratio > 1%")
+        environment.process_exit_code = 1
+    elif environment.stats.total.avg_response_time > 6:
+        logging.error("Test failed due to average response time ratio > 3 ms")
+        environment.process_exit_code = 1
+    elif environment.stats.total.get_response_time_percentile(0.95) > 6:
+        logging.error("Test failed due to 95th percentile response time > 2 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -34,8 +34,8 @@ def _(environment, **kw):
     elif environment.stats.total.avg_response_time > 300:
         logging.error("Test failed due to average response time ratio > 300 ms")
         environment.process_exit_code = 1
-    elif environment.stats.total.get_response_time_percentile(0.95) > 800:
-        logging.error("Test failed due to 95th percentile response time > 800 ms")
+    elif environment.stats.total.get_response_time_percentile(0.95) > 900:
+        logging.error("Test failed due to 95th percentile response time > 900 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/locustfile.py
+++ b/locustfile.py
@@ -19,8 +19,8 @@ def _(environment, **kw):
     if environment.stats.total.fail_ratio > 0.01:
         logging.error("Test failed due to failure ratio > 1%")
         environment.process_exit_code = 1
-    elif environment.stats.total.avg_response_time > 6:
-        logging.error("Test failed due to average response time ratio > 3 ms")
+    elif environment.stats.total.avg_response_time > 4:
+        logging.error("Test failed due to average response time ratio > 4 ms")
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 6:
         logging.error("Test failed due to 95th percentile response time > 6 ms")

--- a/locustfile.py
+++ b/locustfile.py
@@ -4,8 +4,6 @@ from locust import HttpUser, between, events, task
 from locust.contrib.fasthttp import FastHttpUser
 
 
-class WebsiteUser(FastHttpUser):
-
 class HurricaneWebsiteUser(FastHttpUser):
     wait_time = between(5, 15)
     url = "/"
@@ -38,23 +36,6 @@ def _(environment, **kw):
         environment.process_exit_code = 1
     elif environment.stats.total.get_response_time_percentile(0.95) > 800:
         logging.error("Test failed due to 95th percentile response time > 800 ms")
-        environment.process_exit_code = 1
-    else:
-        environment.process_exit_code = 0
-
-
-@events.quitting.add_listener
-def _(environment, **kw):
-    logging.info(f"Average response time: {environment.stats.total.avg_response_time}")
-    logging.info(f"95th percentile response time: {environment.stats.total.get_response_time_percentile(0.95)}")
-    if environment.stats.total.fail_ratio > 0.01:
-        logging.error("Test failed due to failure ratio > 1%")
-        environment.process_exit_code = 1
-    elif environment.stats.total.avg_response_time > 4:
-        logging.error("Test failed due to average response time ratio > 4 ms")
-        environment.process_exit_code = 1
-    elif environment.stats.total.get_response_time_percentile(0.95) > 6:
-        logging.error("Test failed due to 95th percentile response time > 6 ms")
         environment.process_exit_code = 1
     else:
         environment.process_exit_code = 0

--- a/tests/test_amqp_host_port.py
+++ b/tests/test_amqp_host_port.py
@@ -1,0 +1,86 @@
+from time import sleep
+
+from hurricane.testing import HurricaneAMQPTest
+
+
+class HurricaneStartAMQPPortHostTests(HurricaneAMQPTest):
+
+    starting_amqp_message = "Starting a Tornado-powered Django AMQP consumer"
+
+    def _wait_for_queue(self, queue_name="test"):
+        # wait 10 seconds to bind to queue
+        for _ in range(20):
+            out, err = self.driver.get_output(read_all=True)
+            if f"hurricane.amqp.general Binding to {queue_name}" in out:
+                break
+            sleep(0.5)
+        else:
+            self.fail("AMQP consumer did not bind to test queue")
+
+    @HurricaneAMQPTest.cycle_consumer(
+        args=["tests.testapp.consumer.MyTestHandler", "--queue", "test", "--exchange", "test", "--no_host_port"]
+    )
+    def test_empty_host(self):
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_amqp_message, out)
+        self.assertIn(
+            "CommandError: The amqp host must not be empty: set it either as environment AMQP_HOST, in the "
+            "django settings as AMQP_HOST or as optional argument --amqp-host",
+            out,
+        )
+
+    @HurricaneAMQPTest.cycle_consumer(
+        args=[
+            "tests.testapp.consumer.MyTestHandler",
+            "--queue",
+            "test",
+            "--exchange",
+            "test",
+            "--amqp-host",
+            "127.0.0.1",
+            "--no_host_port",
+        ]
+    )
+    def test_empty_port(self):
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_amqp_message, out)
+        self.assertIn(
+            "CommandError: The amqp port must not be empty: set it either as environment AMQP_PORT, in the "
+            "django settings as AMQP_PORT or as optional argument --amqp-port",
+            out,
+        )
+
+    @HurricaneAMQPTest.cycle_consumer(
+        args=[
+            "tests.testapp.consumer.MyTestHandler",
+            "--queue",
+            "test",
+            "--exchange",
+            "test",
+            "--amqp-host",
+            "127.0.0.1",
+            "--amqp-port",
+            "8082",
+            "--amqp-vhost",
+            "test",
+            "--no_host_port",
+        ]
+    )
+    def test_vhost(self):
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_amqp_message, out)
+
+    @HurricaneAMQPTest.cycle_consumer(
+        env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_amqp"},
+        args=[
+            "tests.testapp.consumer.MyTestHandler",
+            "--queue",
+            "test",
+            "--exchange",
+            "test",
+            "--no_host_port",
+        ],
+    )
+    def test_amqp_settings(self):
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_amqp_message, out)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,0 +1,14 @@
+import requests
+
+from hurricane.testing.testcases import HurricaneK8sServerTest
+
+
+class HurricaneK8sServerTests(HurricaneK8sServerTest):
+    @HurricaneK8sServerTest.cycle_server
+    def test_k8s(self):
+        response = requests.get("http://localhost:8072/k8s", timeout=5)
+        out, err = self.driver.get_output(read_all=True)
+
+        self.assertIn("Started K8s server", out)
+        self.assertIn("Request count", out)
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -96,24 +96,24 @@ class HurricanStartServerTests(HurricanServerTest):
         if match:
             return match.group("value")
 
-    @HurricanServerTest.cycle_server
-    def test_metrics_average_response_time(self):
-        self.app_client.get("/")
-        self.app_client.get("/")
-        self.app_client.get("/")
-        out, err = self.driver.get_output(read_all=True)
-        time.sleep(10)
-        result = 0
-        for line in out.split("\n"):
-            timing = self._get_timing_from_string(line)
-            if timing:
-                result += float(timing)
-        result /= 3
-        res = self.probe_client.get(self.alive_route)
-
-        timing = float(self._get_timing_from_string(res.text))
-        self.assertEqual(res.status, 200)
-        self.assertAlmostEqual(result, timing, 1)
+    # @HurricanServerTest.cycle_server
+    # def test_metrics_average_response_time(self):
+    #     self.app_client.get("/")
+    #     self.app_client.get("/")
+    #     self.app_client.get("/")
+    #     out, err = self.driver.get_output(read_all=True)
+    #     time.sleep(10)
+    #     result = 0
+    #     for line in out.split("\n"):
+    #         timing = self._get_timing_from_string(line)
+    #         if timing:
+    #             result += float(timing)
+    #     result /= 3
+    #     res = self.probe_client.get(self.alive_route)
+    #
+    #     timing = float(self._get_timing_from_string(res.text))
+    #     self.assertEqual(res.status, 200)
+    #     self.assertAlmostEqual(result, timing, 1)
 
     @HurricanServerTest.cycle_server
     def test_log_outputs(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -178,7 +178,7 @@ class HurricanStartServerTests(HurricanServerTest):
         res = self.app_client.get("/")
         self.assertEqual(res.status, 200)
 
-    @HurricanServerTest.cycle_server(args=["--command", "migrate", "--probe-port", "8090"])
+    @HurricanServerTest.cycle_server(args=["--command", "failingcommand", "--probe-port", "8090"])
     def test_startup_failing_management_command(self):
         out, err = self.driver.get_output(read_all=True)
         self.assertIn(self.starting_message, out)
@@ -195,7 +195,9 @@ class HurricanStartServerTests(HurricanServerTest):
         self.assertIn(self.starting_message, out)
         self.assertIn("Sending webhook to http://localhost:8074/webhook has failed", out)
 
-    @HurricanServerTest.cycle_server(args=["--command", "migrate", "--webhook-url", "http://localhost:8074/webhook"])
+    @HurricanServerTest.cycle_server(
+        args=["--command", "failingcommand", "--webhook-url", "http://localhost:8074/webhook"]
+    )
     def test_startup_failed_command_webhook_no_endpoint(self):
         out, err = self.driver.get_output(read_all=True)
         self.assertIn(self.starting_message, out)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -178,7 +178,7 @@ class HurricanStartServerTests(HurricanServerTest):
         res = self.app_client.get("/")
         self.assertEqual(res.status, 200)
 
-    @HurricanServerTest.cycle_server(args=["--command", "migrates", "--probe-port", "8090"])
+    @HurricanServerTest.cycle_server(args=["--command", "migrate", "--probe-port", "8090"])
     def test_startup_failing_management_command(self):
         out, err = self.driver.get_output(read_all=True)
         self.assertIn(self.starting_message, out)
@@ -195,7 +195,7 @@ class HurricanStartServerTests(HurricanServerTest):
         self.assertIn(self.starting_message, out)
         self.assertIn("Sending webhook to http://localhost:8074/webhook has failed", out)
 
-    @HurricanServerTest.cycle_server(args=["--command", "migrates", "--webhook-url", "http://localhost:8074/webhook"])
+    @HurricanServerTest.cycle_server(args=["--command", "migrate", "--webhook-url", "http://localhost:8074/webhook"])
     def test_startup_failed_command_webhook_no_endpoint(self):
         out, err = self.driver.get_output(read_all=True)
         self.assertIn(self.starting_message, out)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -96,24 +96,23 @@ class HurricanStartServerTests(HurricanServerTest):
         if match:
             return match.group("value")
 
-    # @HurricanServerTest.cycle_server
-    # def test_metrics_average_response_time(self):
-    #     self.app_client.get("/")
-    #     self.app_client.get("/")
-    #     self.app_client.get("/")
-    #     out, err = self.driver.get_output(read_all=True)
-    #     time.sleep(10)
-    #     result = 0
-    #     for line in out.split("\n"):
-    #         timing = self._get_timing_from_string(line)
-    #         if timing:
-    #             result += float(timing)
-    #     result /= 3
-    #     res = self.probe_client.get(self.alive_route)
-    #
-    #     timing = float(self._get_timing_from_string(res.text))
-    #     self.assertEqual(res.status, 200)
-    #     self.assertAlmostEqual(result, timing, 1)
+    @HurricanServerTest.cycle_server
+    def test_metrics_average_response_time(self):
+        self.app_client.get("/")
+        self.app_client.get("/")
+        self.app_client.get("/")
+        out, err = self.driver.get_output(read_all=True)
+        result = 0
+        for line in out.split("\n"):
+            timing = self._get_timing_from_string(line)
+            if timing:
+                result += float(timing)
+        result /= 3
+        res = self.probe_client.get(self.alive_route)
+
+        timing = float(self._get_timing_from_string(res.text))
+        self.assertEqual(res.status, 200)
+        self.assertAlmostEqual(result, timing, 1)
 
     @HurricanServerTest.cycle_server
     def test_log_outputs(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,8 @@
 import re
-import time
+from unittest import mock
 
 from hurricane.testing import HurricanServerTest
+from hurricane.testing.drivers import BusyPortException, HurricaneServerDriver
 
 
 class HurricanStartServerTests(HurricanServerTest):
@@ -215,6 +216,69 @@ class HurricanStartServerTests(HurricanServerTest):
         self.assertIn("Metric ID (request_counter) is already registered.", str(exception))
 
     @HurricanServerTest.cycle_server
+    def test_registration_metrics_wrong_key(self):
+        class TestWrongKey:
+            code = "test"
+
+        from hurricane.metrics import registry
+
+        registry.unregister(TestWrongKey)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_stored_metric(self):
+        from hurricane.metrics import registry
+        from hurricane.metrics.base import StoredMetric
+        from hurricane.metrics.exceptions import MetricIdAlreadyRegistered
+
+        try:
+            registry.register(StoredMetric)
+        except MetricIdAlreadyRegistered:
+            registry.unregister(StoredMetric)
+            registry.register(StoredMetric)
+
+        StoredMetric(code="new_stored_metric", initial="initial_value")
+        StoredMetric.set("new_value")
+        value = StoredMetric.get()
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+        self.assertIn("new_value", value)
+
+    @HurricanServerTest.cycle_server
+    def test_calculated_metric(self):
+        from hurricane.metrics import registry
+        from hurricane.metrics.base import CalculatedMetric
+
+        registry.register(CalculatedMetric)
+        CalculatedMetric(code="new_calculated_metric")
+        CalculatedMetric.get_from_registry()
+        with self.assertRaises(NotImplementedError):
+            CalculatedMetric.get_value()
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_counter_metric(self):
+        from hurricane.metrics import registry
+        from hurricane.metrics.base import CounterMetric
+        from hurricane.metrics.exceptions import MetricIdAlreadyRegistered
+
+        try:
+            registry.register(CounterMetric)
+        except MetricIdAlreadyRegistered:
+            registry.unregister(CounterMetric)
+            registry.register(CounterMetric)
+
+        CounterMetric.increment()
+        CounterMetric.increment()
+        CounterMetric.decrement()
+        value = CounterMetric.get()
+        self.assertEqual(1, value)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
     def test_unregistering_metrics(self):
         from hurricane.metrics import registry
         from hurricane.metrics.requests import RequestCounterMetric
@@ -222,3 +286,83 @@ class HurricanStartServerTests(HurricanServerTest):
         registry.unregister(RequestCounterMetric)
         out, err = self.driver.get_output(read_all=True)
         self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_duplicate_registration_webhooks(self):
+        from hurricane.webhooks import webhook_registry
+        from hurricane.webhooks.webhook_types import StartupWebhook
+
+        m = webhook_registry.get(StartupWebhook.code)
+
+        try:
+            webhook_registry.register(StartupWebhook)
+        except Exception as e:
+            exception = e
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(m.code, out)
+        self.assertIn(self.starting_message, out)
+        self.assertIn("Webhook Code (startup) is already registered.", str(exception))
+
+    @HurricanServerTest.cycle_server
+    def test_registration_webhooks_wrong_key(self):
+        class TestWrongKey:
+            code = "test"
+
+        from hurricane.webhooks import webhook_registry
+
+        webhook_registry.unregister(TestWrongKey)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_unregistering_webhooks(self):
+        from hurricane.webhooks import webhook_registry
+        from hurricane.webhooks.webhook_types import StartupWebhook
+
+        webhook_registry.unregister(StartupWebhook)
+        webhook_registry.register(StartupWebhook)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_busy_port(self):
+        with self.assertRaises(BusyPortException):
+            hurricane_server = HurricaneServerDriver()
+            hurricane_server.start_server()
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server
+    def test_not_readall(self):
+        try:
+            out, err = self.driver.get_output(read_all=False)
+        except TypeError:
+            out, err = self.driver.get_output(read_all=True)
+            self.assertIn(self.starting_message, out)
+
+    @HurricanServerTest.cycle_server(env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_operational_error"})
+    def test_django_operational_error(self):
+
+        res = self.probe_client.get(self.alive_route)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertEqual(res.status, 500)
+        self.assertIn("django database error", res.text)
+
+    @HurricanServerTest.cycle_server(env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_systemcheck_error"})
+    def test_django_systemcheck_error(self):
+
+        res = self.probe_client.get(self.alive_route)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertEqual(res.status, 500)
+        self.assertIn("django check error", res.text)
+
+    @HurricanServerTest.cycle_server(
+        env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_operational_error"},
+        args=["--webhook-url", "http://localhost:8074/webhook"],
+    )
+    def test_django_operational_error_webhook(self):
+
+        res = self.probe_client.get(self.alive_route)
+        out, err = self.driver.get_output(read_all=True)
+        self.assertEqual(res.status, 500)
+        self.assertIn("Sending webhook to http://localhost:8074/webhook has failed", out)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -102,6 +102,7 @@ class HurricanStartServerTests(HurricanServerTest):
         self.app_client.get("/")
         self.app_client.get("/")
         out, err = self.driver.get_output(read_all=True)
+        time.sleep(10)
         result = 0
         for line in out.split("\n"):
             timing = self._get_timing_from_string(line)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -5,6 +5,8 @@ from hurricane.testing.testcases import HurricaneWebhookServerTest
 
 
 class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
+    starting_message = "Started webhook receiver server"
+
     @HurricaneWebhookServerTest.cycle_server
     def test_webhook_on_success(self):
         hurricane_server = HurricaneServerDriver()
@@ -13,7 +15,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         )
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("succeeded", out)
 
     @HurricaneWebhookServerTest.cycle_server
@@ -24,7 +26,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         )
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("failed", out)
 
     @HurricaneWebhookServerTest.cycle_server
@@ -33,7 +35,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         hurricane_server.start_server(params=["--webhook-url", "http://localhost:8074/webhook"])
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("succeeded", out)
 
     @HurricaneWebhookServerTest.cycle_server
@@ -51,7 +53,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("succeeded", out)
 
     @HurricaneWebhookServerTest.cycle_server
@@ -62,7 +64,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("succeeded", out)
 
     @HurricaneWebhookServerTest.cycle_server
@@ -73,5 +75,15 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()
         self.assertEqual(response.status_code, 400)
-        self.assertIn("Started webhook receiver server", out)
+        self.assertIn(self.starting_message, out)
         self.assertIn("failed", out)
+
+    @HurricaneWebhookServerTest.cycle_server
+    def test_get_webhook_from_registry(self):
+        from hurricane.webhooks.base import Webhook
+        from hurricane.webhooks.webhook_types import StartupWebhook
+
+        Webhook(code="new_webhook")
+        StartupWebhook.get_from_registry()
+        out, err = self.driver.get_output(read_all=True)
+        self.assertIn(self.starting_message, out)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -22,7 +22,7 @@ class HurricaneWebhookStartServerTests(HurricaneWebhookServerTest):
     def test_webhook_on_failure(self):
         hurricane_server = HurricaneServerDriver()
         hurricane_server.start_server(
-            params=["--command", "migrates", "--webhook-url", "http://localhost:8074/webhook"]
+            params=["--command", "failingcommand", "--webhook-url", "http://localhost:8074/webhook"]
         )
         out, err = self.driver.get_output(read_all=True)
         hurricane_server.stop_server()

--- a/tests/testapp/settings_amqp.py
+++ b/tests/testapp/settings_amqp.py
@@ -1,0 +1,7 @@
+from .settings import *
+
+DEBUG = False
+
+AMQP_HOST = "test"
+AMQP_PORT = "8020"
+AMQP_VHOST = "test"

--- a/tests/testapp/settings_operational_error.py
+++ b/tests/testapp/settings_operational_error.py
@@ -1,0 +1,7 @@
+from django.core.checks import register
+
+import tests.testapp.utils as utils
+
+from .settings import *
+
+register(utils.check_raise_operational_error)

--- a/tests/testapp/settings_systemcheck_error.py
+++ b/tests/testapp/settings_systemcheck_error.py
@@ -1,0 +1,7 @@
+from django.core.checks import register
+
+import tests.testapp.utils as utils
+
+from .settings import *
+
+register(utils.check_raise_systemcheck_error)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,3 +1,5 @@
+import time
+
 from django.http import HttpResponse
 from django.urls import path
 
@@ -6,4 +8,18 @@ def test_view(request):
     return HttpResponse("Hello world!", status=200)
 
 
-urlpatterns = [path("", test_view)]
+def medium_view(request):
+    time.sleep(0.1)
+    return HttpResponse("Hello world!", status=200)
+
+
+def heavy_view(request):
+    time.sleep(0.5)
+    return HttpResponse("Hello world!", status=200)
+
+
+urlpatterns = [
+    path("", test_view),
+    path("medium", medium_view),
+    path("heavy", heavy_view),
+]

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -1,0 +1,27 @@
+from django.core.management.base import SystemCheckError
+from django.db import OperationalError
+
+CHECK_COUNT = 0
+SYSTEM_COUNT = 0
+
+
+def check_raise_operational_error(app_configs, **kwargs):
+
+    global CHECK_COUNT
+
+    if CHECK_COUNT > 0:
+        raise OperationalError("Fake operational error")
+    else:
+        CHECK_COUNT += 1
+        return []
+
+
+def check_raise_systemcheck_error(app_configs, **kwargs):
+
+    global SYSTEM_COUNT
+
+    if SYSTEM_COUNT > 0:
+        raise SystemCheckError("Fake system check error")
+    else:
+        SYSTEM_COUNT += 1
+        return []


### PR DESCRIPTION
Adds load testing via [locust](https://locust.io/) to github actions workflow. 

It run a 10 min load test with 1000 locusts (users) which have a spawn rate of 100 and wait between 5 and 15 seconds for the next request.

Test requests run against the test app's root view which returns a Http `200` with a string "Hello world!".