### PR TITLE
feat: add remote debugger option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,14 @@ repos:
         # check out their meaning here
         # https://flake8.pycqa.org/en/latest/user/error-codes.html
         - "--ignore=E203,E266,E501,W503,F403,F401,E402"
+      language_version: python3.8
 
 # isort - organize import correctly
 - repo: https://github.com/PyCQA/isort
   rev: 5.6.4
   hooks:
   - id: isort
+    language_version: python3.8
 
 # gitlint - correct git commit format
 -   repo: https://github.com/jorisroovers/gitlint

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Command options for *serve*-command:
 | --liveness-probe   | The exposed path (default is /alive) for probes to check liveness |
 | --check-migrations | Check if all migrations were applied before starting application |
 | --webhook-url      | If specified, webhooks will be sent to this url |
+| --pycharm-host     | The host of the pycharm debug server |  
+| --pycharm-port     | The port of the pycharm debug server. This is only used in combination with the '--pycharm-host' option |  
 
 **Please note**: `req-queue-len` parameter is set to a default value of 10. It means, that if the length of
 asynchronous tasks queue will exceed 10, readiness probe will return status 400 until the length of tasks gets below the
@@ -258,4 +260,35 @@ To build the docs following command should be started in a docs directory:
 make html
 ```
 
-[0]: https://github.com/microsoft/vscode-debugadapter-node/blob/main/debugProtocol.json
+## Debugging django applications
+Debugging a python/django or in fact any application running in a kubernetes cluster can be cumbersome. Some of the most 
+common IDEs use different approaches to remote debugging: 
+
+1. The [Microsoft Debug Adapter Protocol (DAP)][0] is used, among others, by Visual Studio Code and Eclipse.
+   Here, the application itself must listen on a port and wait for the debug client (in this case: the IDE's debug UI)
+   to connect. 
+2. Pycharm, which uses the [pydevd][2] debugger, sets up a debug server (you will have to configure a host 
+   and a port in your IDE debug run config) and waits for the application to connect. Therefore, the application must 
+   know where to reach the debug server.
+
+Both approaches would usually require the application to contain code that is specific to the IDE/protocol used by the 
+developer. Django-hurricane supports these two approaches without the need for changes to your django project:
+
+1. For the Debug Adapter Protocol (Visual Studio Code, Eclipse, ...)  
+   a. Install Djanog-hurricane with the "debug" option: `pip install django-hurricane[debug]`   
+   b. Run it with the "--debugger" flag, e.g.: `python manage.py serve --debugger`  
+   c. Optionally, provide a port (default: 5678), e.g.: `python manage.py serve --debugger --debugger-port 1234`  
+   Now you can connect your IDE's remote debug client (configure the appropriate host and port).
+2. For working with the Pycharm debugger:
+   a. Install Djanog-hurricane with the "pycharm" option: `pip install django-hurricane[pycharm]`  
+   b. Configure the remote debug server in Pycharm and start it
+   c. Run your app with the "--pycharm-host" and "--pycharm-port" flags, e.g.: `python manage.py serve --pycharm-host 127.0.0.1 --pycharm-port 1234`  
+   Now, the app should connect to the debug server. Upon connection, the execution will halt. You must resume it from 
+   Pycharm's debugger UI. 
+
+For both approaches, you may have to configure path mappings in your IDE that map your local source code directories to 
+the corresponding locations inside the running container (e.g. "/home/me/proj/src" -> "/app"). 
+
+[0]: https://microsoft.github.io/debug-adapter-protocol/
+[1]: https://code.visualstudio.com/
+[2]: https://github.com/fabioz/PyDev.Debugger

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Debugging a python/django or in fact any application running in a kubernetes clu
 common IDEs use different approaches to remote debugging: 
 
 1. The [Microsoft Debug Adapter Protocol (DAP)][0] is used, among others, by Visual Studio Code and Eclipse.
+   A full list of supporting IDE's can be found [here][3].
    Here, the application itself must listen on a port and wait for the debug client (in this case: the IDE's debug UI)
    to connect. 
 2. Pycharm, which uses the [pydevd][2] debugger, sets up a debug server (you will have to configure a host 
@@ -292,3 +293,4 @@ the corresponding locations inside the running container (e.g. "/home/me/proj/sr
 [0]: https://microsoft.github.io/debug-adapter-protocol/
 [1]: https://code.visualstudio.com/
 [2]: https://github.com/fabioz/PyDev.Debugger
+[3]: https://microsoft.github.io/debug-adapter-protocol/implementors/tools/

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Command options for *serve*-command:
 | --static           | Serve collected static files |  
 | --media            | Serve media files |  
 | --autoreload       | Reload code on change |  
-| --debug            | Set Tornado's Debug flag (don't confuse with Django's DEBUG=True) |  
+| --debug            | Set Tornado's Debug flag (don't confuse with Django's DEBUG=True) | 
+| --debugger         | Open a port for a debugger client to connect to according to the [Debug Adapter Protocol][0] | 
+| --debugger-port    | Which port to open for the debug client (default: 5678). This is ignored if `--debugger` is not used |  
 | --port             | The port for Tornado to listen on (default is port 8000) |  
 | --probe-port       | The port for Tornado probe routes to listen on (default is the next port of --port) |  
 | --no-probe         | Disable probe endpoint |  
@@ -256,3 +258,4 @@ To build the docs following command should be started in a docs directory:
 make html
 ```
 
+[0]: https://github.com/microsoft/vscode-debugadapter-node/blob/main/debugProtocol.json

--- a/hurricane/management/commands/serve.py
+++ b/hurricane/management/commands/serve.py
@@ -88,6 +88,10 @@ class Command(BaseCommand):
         parser.add_argument("--command", type=str, action="append", nargs="+")
         parser.add_argument("--check-migrations", action="store_true", help="Check if migrations were applied")
         parser.add_argument(
+            "--debugger", action="store_true", help="Open a debugger port according to the Debug Adapter Protocol"
+        )
+        parser.add_argument("--debugger-port", type=int, default=5678, help="The port for the debug client to attach")
+        parser.add_argument(
             "--webhook-url",
             type=str,
             help="Url for webhooks",
@@ -137,6 +141,17 @@ class Command(BaseCommand):
         else:
             logger.info("No probe application running")
 
+        if options["debugger"]:
+            try:
+                import debugpy
+            except ImportError:
+                logger.warning(
+                    "Ignoring '--debugger' flag because module 'debugpy' was not found. "
+                    "Make sure to install 'django-hurricane' with the 'debug' option, "
+                    "e.g. 'pip install django-hurricane[debug]'."
+                )
+            else:
+                debugpy.listen(("0.0.0.0", options["debugger_port"]))
         loop = asyncio.get_event_loop()
 
         make_http_server_wrapper = functools.partial(

--- a/hurricane/management/commands/serve.py
+++ b/hurricane/management/commands/serve.py
@@ -16,6 +16,7 @@ from hurricane.server import (
     make_http_server_and_listen,
     make_probe_server,
 )
+from hurricane.server.debugging import setup_debugpy, setup_pycharm
 from hurricane.webhooks import StartupWebhook
 from hurricane.webhooks.base import WebhookStatus
 
@@ -142,38 +143,8 @@ class Command(BaseCommand):
         else:
             logger.info("No probe application running")
 
-        if options["debugger"]:
-            try:
-                import debugpy
-            except ImportError:
-                logger.warning(
-                    "Ignoring '--debugger' flag because module 'debugpy' was not found. "
-                    "Make sure to install 'django-hurricane' with the 'debug' option, "
-                    "e.g. 'pip install django-hurricane[debug]'."
-                )
-            else:
-                debugpy.listen(("0.0.0.0", options["debugger_port"]))
-
-        if options["pycharm_host"]:
-            try:
-                import pydevd_pycharm
-            except ImportError:
-                logger.warning(
-                    "Ignoring '--pycharm_host' option because module 'pydevd_pycharm' was not found. "
-                    "Make sure to install 'django-hurricane' with the 'pycharm' option, "
-                    "e.g. 'pip install django-hurricane[pycharm]' or install your required version "
-                    "of 'pydevd-pycharm' manually."
-                )
-            else:
-                host = options["pycharm_host"]
-                port = options["pycharm_port"]
-                if port:
-                    pydevd_pycharm.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
-                else:
-                    logger.warning(
-                        "No '--pycharm-port' was specified. The '--pycharm-host' option can "
-                        "only be used in combination with the '--pycharm-port' option. "
-                    )
+        setup_debugpy(options)
+        setup_pycharm(options)
 
         loop = asyncio.get_event_loop()
 

--- a/hurricane/server/debugging.py
+++ b/hurricane/server/debugging.py
@@ -1,0 +1,41 @@
+from hurricane.server import logger
+
+
+def setup_debugpy(options):
+    if options["debugger"]:
+        try:
+            import debugpy
+        except ImportError:
+            logger.warning(
+                "Ignoring '--debugger' flag because module 'debugpy' was not found. "
+                "Make sure to install 'django-hurricane' with the 'debug' option, "
+                "e.g. 'pip install django-hurricane[debug]'."
+            )
+        else:
+            port = options["debugger_port"]
+            debugpy.listen(("0.0.0.0", port))
+            logger.info(f"Listening for debug clients at port {port}")
+
+
+def setup_pycharm(options):
+    if options["pycharm_host"]:
+        try:
+            import pydevd_pycharm
+        except ImportError:
+            logger.warning(
+                "Ignoring '--pycharm_host' option because module 'pydevd_pycharm' was not found. "
+                "Make sure to install 'django-hurricane' with the 'pycharm' option, "
+                "e.g. 'pip install django-hurricane[pycharm]' or install your required version "
+                "of 'pydevd-pycharm' manually."
+            )
+        else:
+            host = options["pycharm_host"]
+            port = options["pycharm_port"]
+            if port:
+                pydevd_pycharm.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
+                logger.info(f"Connected to debug server at {host}:{port}")
+            else:
+                logger.warning(
+                    "No '--pycharm-port' was specified. The '--pycharm-host' option can "
+                    "only be used in combination with the '--pycharm-port' option. "
+                )

--- a/hurricane/server/debugging.py
+++ b/hurricane/server/debugging.py
@@ -32,8 +32,11 @@ def setup_pycharm(options):
             host = options["pycharm_host"]
             port = options["pycharm_port"]
             if port:
-                pydevd_pycharm.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
-                logger.info(f"Connected to debug server at {host}:{port}")
+                try:
+                    pydevd_pycharm.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
+                    logger.info(f"Connected to debug server at {host}:{port}")
+                except Exception:
+                    logger.warning("Could not connect to debug server at {host}:{port}")
             else:
                 logger.warning(
                     "No '--pycharm-port' was specified. The '--pycharm-host' option can "

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     long_description_content_type="text/markdown",
     version=VERSION,
     install_requires=["tornado~=6.1", "Django>=2.2", "asgiref~=3.4.0", "pika~=1.1.0", "requests~=2.25"],
-    extras_require={"debug": ["debugpy~=1.5"]},
+    extras_require={
+        "debug": ["debugpy~=1.5"],
+        "pycharm": ["pydevd-pycharm~=213.5605.23"],
+    },
     python_requires="~=3.8",
     packages=[
         "hurricane",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     version=VERSION,
     install_requires=["tornado~=6.1", "Django>=2.2", "asgiref~=3.4.0", "pika~=1.1.0", "requests~=2.25"],
+    extras_require={"debug": ["debugpy~=1.5"]},
     python_requires="~=3.8",
     packages=[
         "hurricane",


### PR DESCRIPTION
add flags "--debugger" and "--debugger-port" which open up a port for a debug client to connect to,
add documentation for those flags
fix language version for isort, flake8 git hooks
add warning message if debugpy is not installed