### PR TITLE
Custom async metrics

### DIFF
--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -25,9 +25,37 @@ variable, which is used as a key for storing and retrieving value from the regis
 also registered in a metric registry. This can be done by adding the following lines to init file of metrics package:
 ::
     # file: metrics/__init__.py
+    from hurricane.metrics import registry
     from hurricane.metrics.requests import <CustomMetricClass>
 
     registry.register(<CustomMetricClass>)
+
+
+.. hint:: Dont't forget to import the metrics in your Django app. We recommend doing this in the AppConfig.ready() method.
+
+It is possible to add both synchronous and asynchronous custom metrics:
+
+::
+    # file: metrics/__init__.py
+    from hurricane.metrics.base import InfoMetrics
+
+    class CustomMetric(InfoMetrics):
+        code = "custom_metric_code"
+        is_async = True
+        prometheus = Gauge(
+            "processed_order", "Number of orders that have been processed."
+        )
+        value = 1
+
+        @classmethod
+        async def get(cls):
+            value = await Order.objects.filter(
+                status=Order.PROCESSED,
+            ).acount()
+            cls.prometheus.set(value)
+            cls.value = value
+
+This is particularly useful when the metric value needs to be fetched from an external source, such as a database or an API.
 
 
 Disable Metrics

--- a/hurricane/metrics/base.py
+++ b/hurricane/metrics/base.py
@@ -4,12 +4,15 @@ from prometheus_client import Counter, Gauge, Histogram
 
 CONTINUOUS_LOOP_TASKS = 5  # 5 is the number of tasks that are always running
 
+
 class HurricaneMetric:
     """
     Base class for storing metrics in registry.
     """
+
     is_async: bool = False
     code: str = ""
+
 
 class StoredMetric(HurricaneMetric):
     value: Optional[Any] = None
@@ -82,6 +85,7 @@ class CounterMetric(StoredMetric):
     """
     Metric, that can be incremented and decremented.
     """
+
     value = 0
     prometheus: Optional[Counter] = None
 
@@ -108,6 +112,7 @@ class AverageMetric(StoredMetric):
     """
     Calculating average of a metric.
     """
+
     counter = 0
     value = 0
     prometheus: Optional[Gauge] = None
@@ -130,6 +135,7 @@ class ObservedMetric(StoredMetric):
     """
     Metric, that can be oberserved.
     """
+
     value = 0
     prometheus: Optional[Histogram] = None
 

--- a/hurricane/metrics/base.py
+++ b/hurricane/metrics/base.py
@@ -4,13 +4,14 @@ from prometheus_client import Counter, Gauge, Histogram
 
 CONTINUOUS_LOOP_TASKS = 5  # 5 is the number of tasks that are always running
 
-
-class StoredMetric:
+class HurricaneMetric:
     """
     Base class for storing metrics in registry.
     """
-
+    is_async: bool = False
     code: str = ""
+
+class StoredMetric(HurricaneMetric):
     value: Optional[Any] = None
 
     def __init__(self, code=None, initial=None):
@@ -48,9 +49,7 @@ class StoredMetric:
         return metric.value
 
 
-class CalculatedMetric:
-    code: str = ""
-
+class CalculatedMetric(HurricaneMetric):
     def __init__(self, code=None):
         if code:
             self.code = code
@@ -83,8 +82,6 @@ class CounterMetric(StoredMetric):
     """
     Metric, that can be incremented and decremented.
     """
-
-    code: str = ""
     value = 0
     prometheus: Optional[Counter] = None
 
@@ -111,7 +108,6 @@ class AverageMetric(StoredMetric):
     """
     Calculating average of a metric.
     """
-
     counter = 0
     value = 0
     prometheus: Optional[Gauge] = None
@@ -134,8 +130,6 @@ class ObservedMetric(StoredMetric):
     """
     Metric, that can be oberserved.
     """
-
-    code: str = ""
     value = 0
     prometheus: Optional[Histogram] = None
 

--- a/hurricane/metrics/registry.py
+++ b/hurricane/metrics/registry.py
@@ -1,4 +1,3 @@
-from hurricane.metrics.base import HurricaneMetric
 from hurricane.metrics.exceptions import MetricIdAlreadyRegistered
 
 

--- a/hurricane/metrics/registry.py
+++ b/hurricane/metrics/registry.py
@@ -8,16 +8,16 @@ class MetricsRegistry:
     """
 
     def __init__(self) -> None:
-        self.metrics: dict[str, HurricaneMetric] = {}
+        self.metrics: dict = {}
 
-    def register(self, metric_cls: type[HurricaneMetric]):
+    def register(self, metric_cls):
         if metric_cls.code in self.metrics:
             raise MetricIdAlreadyRegistered(
                 f"Metric ID ({metric_cls.code}) is already registered."
             )
         self.metrics[metric_cls.code] = metric_cls()
 
-    def unregister(self, metric_cls: type[HurricaneMetric]):
+    def unregister(self, metric_cls):
         try:
             del self.metrics[metric_cls.code]
         except KeyError:

--- a/hurricane/metrics/registry.py
+++ b/hurricane/metrics/registry.py
@@ -24,5 +24,5 @@ class MetricsRegistry:
             # TODO warn about trying to unregister not registered metric
             pass
 
-    def get(self, code: str) -> HurricaneMetric:
+    def get(self, code: str):
         return self.metrics[code]

--- a/hurricane/metrics/registry.py
+++ b/hurricane/metrics/registry.py
@@ -1,28 +1,28 @@
+from hurricane.metrics.base import HurricaneMetric
 from hurricane.metrics.exceptions import MetricIdAlreadyRegistered
 
 
 class MetricsRegistry:
-
     """
     Registering metrics and storing them in a metrics dictionary.
     """
 
-    def __init__(self):
-        self.metrics = {}
+    def __init__(self) -> None:
+        self.metrics: dict[str, HurricaneMetric] = {}
 
-    def register(self, metric_cls):
+    def register(self, metric_cls: type[HurricaneMetric]):
         if metric_cls.code in self.metrics:
             raise MetricIdAlreadyRegistered(
                 f"Metric ID ({metric_cls.code}) is already registered."
             )
         self.metrics[metric_cls.code] = metric_cls()
 
-    def unregister(self, metric_cls):
+    def unregister(self, metric_cls: type[HurricaneMetric]):
         try:
             del self.metrics[metric_cls.code]
         except KeyError:
             # TODO warn about trying to unregister not registered metric
             pass
 
-    def get(self, code):
+    def get(self, code: str) -> HurricaneMetric:
         return self.metrics[code]

--- a/hurricane/server/django.py
+++ b/hurricane/server/django.py
@@ -293,7 +293,10 @@ class PrometheusHandler(tornado.web.RequestHandler):
         Transmitting incoming request to the Prometheus application via WSGI Container.
         """
         for _, metric in registry.metrics.items():
-            metric.get()
+            if metric.is_async:
+                await metric.get()
+            else:
+                metric.get()
 
         self.prometheus(self.request)
         self._finished = True

--- a/tests/test_w_custom_metrics.py
+++ b/tests/test_w_custom_metrics.py
@@ -1,0 +1,24 @@
+from prometheus_client.parser import text_string_to_metric_families
+
+from hurricane.testing.testcases import HurricanServerTest
+
+
+class HurricanStartServerTests(HurricanServerTest):
+    metrics_route = "/metrics"
+    starting_message = "Tornado-powered Django web server"
+    starting_http_message = "Starting Prometheus metrics exporter on port "
+
+    @HurricanServerTest.cycle_server(env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_metrics"})
+    def test_custom_metrics(self):
+        found_sync = False
+        found_async = False
+        res = self.probe_client.get(self.metrics_route)
+        families = text_string_to_metric_families(res.text)
+        for fam in families:
+            if fam.name == "test_metric":
+                found_sync = True
+            if fam.name == "test_metric_async":
+                found_async = True
+
+        self.assertTrue(found_sync, msg="Synchronous metric not found in /metrics output")
+        self.assertTrue(found_async, msg="Asynchronous metric not found in /metrics output")

--- a/tests/test_w_custom_metrics.py
+++ b/tests/test_w_custom_metrics.py
@@ -8,7 +8,9 @@ class HurricanStartServerTests(HurricanServerTest):
     starting_message = "Tornado-powered Django web server"
     starting_http_message = "Starting Prometheus metrics exporter on port "
 
-    @HurricanServerTest.cycle_server(env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_metrics"})
+    @HurricanServerTest.cycle_server(
+        env={"DJANGO_SETTINGS_MODULE": "tests.testapp.settings_metrics"}
+    )
     def test_custom_metrics(self):
         found_sync = False
         found_async = False
@@ -20,5 +22,9 @@ class HurricanStartServerTests(HurricanServerTest):
             if fam.name == "test_metric_async":
                 found_async = True
 
-        self.assertTrue(found_sync, msg="Synchronous metric not found in /metrics output")
-        self.assertTrue(found_async, msg="Asynchronous metric not found in /metrics output")
+        self.assertTrue(
+            found_sync, msg="Synchronous metric not found in /metrics output"
+        )
+        self.assertTrue(
+            found_async, msg="Asynchronous metric not found in /metrics output"
+        )

--- a/tests/testapp/settings_metrics.py
+++ b/tests/testapp/settings_metrics.py
@@ -1,0 +1,32 @@
+from prometheus_client import Counter
+from .settings import *
+
+from hurricane.metrics import registry
+from hurricane.metrics.base import CounterMetric, CalculatedMetric
+
+
+class TestMetric(CounterMetric):
+        code = "test_metric"
+        description = "A test counter metric"
+        prometheus = Counter('test_metric', 'Description of counter') 
+
+
+class TestAsyncMetric(CalculatedMetric):
+        code = "test_metric_async"
+        description = "A test async counter metric"
+        prometheus = Counter('test_metric_async', 'Description of async counter') 
+        is_async = True
+
+        @classmethod
+        async def get(cls):
+            # Simulate an asynchronous computation
+            import asyncio
+            await asyncio.sleep(0.1)
+            return 42
+
+
+
+registry.register(TestMetric)
+registry.register(TestAsyncMetric)
+
+TestMetric.increment()

--- a/tests/testapp/settings_metrics.py
+++ b/tests/testapp/settings_metrics.py
@@ -6,24 +6,24 @@ from hurricane.metrics.base import CounterMetric, CalculatedMetric
 
 
 class TestMetric(CounterMetric):
-        code = "test_metric"
-        description = "A test counter metric"
-        prometheus = Counter('test_metric', 'Description of counter') 
+    code = "test_metric"
+    description = "A test counter metric"
+    prometheus = Counter("test_metric", "Description of counter")
 
 
 class TestAsyncMetric(CalculatedMetric):
-        code = "test_metric_async"
-        description = "A test async counter metric"
-        prometheus = Counter('test_metric_async', 'Description of async counter') 
-        is_async = True
+    code = "test_metric_async"
+    description = "A test async counter metric"
+    prometheus = Counter("test_metric_async", "Description of async counter")
+    is_async = True
 
-        @classmethod
-        async def get(cls):
-            # Simulate an asynchronous computation
-            import asyncio
-            await asyncio.sleep(0.1)
-            return 42
+    @classmethod
+    async def get(cls):
+        # Simulate an asynchronous computation
+        import asyncio
 
+        await asyncio.sleep(0.1)
+        return 42
 
 
 registry.register(TestMetric)

--- a/tests/testapp/settings_metrics.py
+++ b/tests/testapp/settings_metrics.py
@@ -1,8 +1,9 @@
 from prometheus_client import Counter
-from .settings import *
 
 from hurricane.metrics import registry
-from hurricane.metrics.base import CounterMetric, CalculatedMetric
+from hurricane.metrics.base import CalculatedMetric, CounterMetric
+
+from .settings import *
 
 
 class TestMetric(CounterMetric):


### PR DESCRIPTION
This PR add support for async metrics.
This allows to pull metrics from an external source like a database or another api.
